### PR TITLE
fix: 修复 SegmentedControl values 为空数组时报错

### DIFF
--- a/js/SegmentsSeparators.js
+++ b/js/SegmentsSeparators.js
@@ -24,7 +24,7 @@ export const SegmentsSeparators = ({
 
   return (
     <View style={styles.separatorsContainer}>
-      {[...Array(values - 1).keys()].map((val) => {
+      {[...Array(Math.max(values - 1, 0)).keys()].map((val) => {
         return (
           <View
             key={val}


### PR DESCRIPTION
本 PR 修复了当 `SegmentedControl` 的 `values` 传入空数组时，导致的运行时崩溃问题（`RangeError: Invalid array length`）。

### 问题原因
当 `values`（代表分段数量）为 `0` 时，表达式 `values - 1` 的计算结果为 `-1`。在 JavaScript 中，向 `Array` 构造函数传入负数（如 `Array(-1)`）会直接抛出 `RangeError` 异常，导致应用崩溃。

### 解决方案
使用 `Math.max(values - 1, 0)` 限制参数的最小值为 `0`。这样可以确保传入 `Array` 构造器的参数永远不为负数。当没有分段数据时，它会安全地返回空数组，不渲染任何分割线，从而避免崩溃。