### PR TITLE
pre-release: @react-native-ohos/segmented-control@2.6.1-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 ## 鸿蒙化Log
+### v2.6.1-rc.1
+- pre-release version 2.6.1-rc.1
+- fix: fix SegmentedControl error when values is empty
+
 ### v2.5.8-rc.1
 - pre-release version 2.5.8-rc.1
 - feat: add OpneHarmony support for @react-native-segmented-control/segmented-control

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-ohos/segmented-control",
-  "version": "2.6.0",
+  "version": "2.6.1-rc.1",
   "description": "React Native SegmentedControlIOS library",
   "main": "js/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
本项目用于发布 `@react-native-ohos/segmented-control` 的预发布版本 `2.6.1-rc.1`。

### 主要变更
1. **版本升级**：将 `package.json` 中的版本号更新为 `2.6.1-rc.1`。
2. **更新日志**：在 `CHANGELOG.md` 中补充了 `v2.6.1-rc.1` 的更新内容。
3. **缺陷修复**：此版本包含对 `SegmentedControl` 在 `values` 属性为空数组时引发崩溃问题的修复（即限制 `Array` 构造函数参数的最小值为 0）。